### PR TITLE
Add a duplicate across function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ METABASE_PASSWORD=xxx
 
 `--name` is optional, if it's not provided it will use the same question name.
 
+### Duplicate Question on Destination Instance
+
+`node app.js duplicateAcross —-questionId=[question_id] --collectionId=[collection_id] -—name=[name] -—databaseId=[database_id]`
+
+`--name` is optional, if it's not provided it will use the same question name.
 
 ## Work in Progress
 

--- a/app.js
+++ b/app.js
@@ -87,6 +87,53 @@ yargs.command({
 })
 
 yargs.command({
+    command: 'duplicateAcross',
+    describe: 'Duplicate question across environments',
+    builder: {
+        questionId: {
+            describe: 'Question that will be duplicated on destination',
+            demandOption: true,
+            type: 'number'
+        },
+        name: {
+            describe: 'New question name',
+            demandOption: false,
+            type: 'string'
+        },
+        collectionId: {
+            describe: 'Destination collection of new question',
+            demandOption: true,
+            type: 'number'
+        },
+        databaseId: {
+            describe: 'Destination Database ID for new question',
+            demandOption: true,
+            type: 'number'
+        }
+    },
+    async handler(argv) {
+        try {
+            const response = await metabase_async_await.duplicateAcross(argv.questionId, argv.collectionId, argv.name, argv.databaseId)
+            console.log("\n--------New Question Created!-------")
+            console.log("Response status code", response.status, response.statusText)
+            console.log("ID:", response.data.id)
+            console.log("Name:", response.data.name)
+            console.log("Collection:", response.data.collection.name)
+            console.log("Updated At:", response.data.updated_at)
+            console.log("Database ID:", response.data.dataset_query.database)
+        } catch (error) {
+            if (error.response) {
+                console.log("\nError!", error.response.status, error.response.statusText);
+                console.log(error.response.data);
+            } else{
+                console.log(error);
+            }
+            
+        }   
+    }
+})
+
+yargs.command({
     command: 'update-deprecated',
     describe: 'Update question',
     builder: {

--- a/src/metabase-async-await.js
+++ b/src/metabase-async-await.js
@@ -6,6 +6,12 @@ const baseUrl = process.env.METABASE_BASE_URL
 const username = process.env.METABASE_USERNAME
 const password = process.env.METABASE_PASSWORD
 
+const {
+  DESTINATION_METABASE_BASE_URL,
+  DESTINATION_METABASE_USERNAME,
+  DESTINATION_METABASE_PASSWORD
+} = process.env;
+
 async function update(originQuestionId, destinationQuestionId, destinationDatabaseId) {
   console.log("Authenticating",username);
   const axiosConfig = await auth();
@@ -69,6 +75,66 @@ async function duplicate(questionId, collectionId, questionName, databaseId) {
   return response;
 }
 
+async function duplicateAcross(questionId, collectionId, questionName, databaseId) {
+  console.log("Authenticating",username);
+  const axiosConfigSource = await auth();
+  console.log("Successfully authenticated to source with token", axiosConfigSource.headers);
+
+  console.log("Authenticating",DESTINATION_METABASE_USERNAME);
+  const axiosConfigDestination = await destinationAuth();
+  console.log("Successfully authenticated to destination with token", axiosConfigDestination.headers);
+
+  console.log("From source retrieving question id", questionId);
+  const {visualization_settings, description, enable_embedding, collection_position,
+     result_metadata, dataset_query, display, embedding_params, name:oldName } = await getQuestion(questionId, axiosConfigSource);
+  dataset_query.database = databaseId;
+
+  const name = questionName ? questionName : oldName;
+
+  const body = {
+    visualization_settings,
+    description,
+    collection_id: collectionId,
+    collection_position,
+    result_metadata,
+    dataset_query,
+    name,
+    display,
+    enable_embedding,
+    embedding_params
+  };
+  console.log("\nCreating new question on destination with payload...");
+  console.log(body);
+  const url = DESTINATION_METABASE_BASE_URL + "/card/";
+
+  const response = await axios.post(url, body, axiosConfigDestination);
+  return response;
+}
+
+async function destinationAuth() {
+  try {
+      const authResponse = await axios({
+          method: 'post',
+          url: DESTINATION_METABASE_BASE_URL+ "/session",
+          data: {
+              username: DESTINATION_METABASE_USERNAME,
+              password: DESTINATION_METABASE_PASSWORD
+          }
+      });
+      const token = authResponse.data.id;
+      const axiosConfig = {
+          headers: {
+              "X-Metabase-Session": token
+          }
+      };
+      
+      return axiosConfig;
+  } catch (error) {
+      console.log("error", error.response.status);
+      return
+  }
+}
+
 async function auth() {
   try {
       const authResponse = await axios({
@@ -105,5 +171,5 @@ async function getQuestion(id, axiosConfig) {
 
 
 module.exports = {
-  update, duplicate
+  update, duplicate, duplicateAcross
 }


### PR DESCRIPTION
Add function `duplicateAcross` to copy a question from one Metabase instance to another instance. Not the cleanest, but this is what we did to suit our immediate needs.