### PR TITLE
Test containers for testing cli commands 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ Clone this repository and `npm install`
 
 Create .env file in root folder that contains
 
-```
+```sh
 METABASE_BASE_URL=xxx
 METABASE_USERNAME=xxx
 METABASE_PASSWORD=xxx
+
+# Optionaly, when performing actions on the source Metabase instance above to a destination/second Metabase instance, add the following
+DESTINATION_METABASE_BASE_URL=xxx
+DESTINATION_METABASE_USERNAME=xxx
+DESTINATION_METABASE_PASSWORD=xxx
 ```
 
 ### Update Question
@@ -26,6 +31,11 @@ METABASE_PASSWORD=xxx
 
 `--name` is optional, if it's not provided it will use the same question name.
 
+### Duplicate Question on Destination Instance
+
+`node app.js duplicateAcross —-questionId=[question_id] --collectionId=[collection_id] -—name=[name] -—databaseId=[database_id]`
+
+`--name` is optional, if it's not provided it will use the same question name.
 
 ## Work in Progress
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,58 @@ DESTINATION_METABASE_PASSWORD=xxx
 
 - Duplicating or updating question between different metabase instance
 - Duplicating or updating Dashboard
+
+
+## Testing with Custom Metabase image just past initial setup
+
+** Note: this container should be used for testing purposes only!!! **
+
+Use the image already generated using the steps below (assumed to be using in the `docker-compose.yaml` file): 
+
+```sh
+docker-compose up
+```
+
+You should then have a source `localhost:3000` and destination `localhost:3001` container to execute commands against. Add the following test `.env` file to your project to use them:
+
+```sh
+# source instance
+METABASE_BASE_URL=http://localhost:3000/api
+METABASE_USERNAME=test@test.com
+METABASE_PASSWORD=test1234
+
+# destination instance
+DESTINATION_METABASE_BASE_URL=http://localhost:3001/api
+DESTINATION_METABASE_USERNAME=test@test.com
+DESTINATION_METABASE_PASSWORD=test1234
+```
+
+Sanity check by running the following: `node app.js duplicateAcross --questionId=6 --collectionId=2 --name="testing coordinates copy across instances" --databaseId=1`
+
+If successful, you should be able to view the question @ [localhost:3001/collection/2](http://localhost:3001/collection/2)
+
+### Steps to generate a post install metabse image
+
+The following are the steps followed to generate the image used in the `docker-compose.yaml`:
+
+1. From cli, run `docker run -it -p 3000:3000 --name metabase metabase/metabase[:TAG]`
+1. Once container is launched, visit [localhost:3000/setup](http://localhost:3000/setup)
+1. Click `Let's get started`
+1. Select `English` as preferred language
+1. Enter the following:
+    * First name: `test`
+    * Last name: `test`
+    * Email: `test@test.com`
+    * Create a password: `test1234`
+    * Your company or team name: `test`
+1. Click `Next`
+1. Select `I'll add my data later`
+1. Click `Next`
+1. Click `Take me to Metabase`
+1. Under the `TRY THESE X-RAYS BASED ON YOUR DATA.` section, click `A look at your People table`
+1. Click `Save this`
+1. Verify that you have a new collection (id 2 in URL) called `Automatically Generated Dashboards`
+1. Verify that you have a new collection (id 3 in URL) called `A look at your People table`
+1. Back on the cli, run the following to generate a snapshot of the image: `docker commit metabase mafs/metabase-custom[:TAG]`
+1. Push your image to dockerhub: `docker push mafs/metabase-custom[:TAG]`
+1. Launch 2 instances (a source and destination instance) to run tests against containers: `docker-compose up`

--- a/app.js
+++ b/app.js
@@ -87,6 +87,53 @@ yargs.command({
 })
 
 yargs.command({
+    command: 'duplicateAcross',
+    describe: 'Duplicate question across environments',
+    builder: {
+        questionId: {
+            describe: 'Question that will be duplicated on destination',
+            demandOption: true,
+            type: 'number'
+        },
+        name: {
+            describe: 'New question name',
+            demandOption: false,
+            type: 'string'
+        },
+        collectionId: {
+            describe: 'Destination collection of new question',
+            demandOption: true,
+            type: 'number'
+        },
+        databaseId: {
+            describe: 'Destination Database ID for new question',
+            demandOption: true,
+            type: 'number'
+        }
+    },
+    async handler(argv) {
+        try {
+            const response = await metabase_async_await.duplicateAcross(argv.questionId, argv.collectionId, argv.name, argv.databaseId)
+            console.log("\n--------New Question Created!-------")
+            console.log("Response status code", response.status, response.statusText)
+            console.log("ID:", response.data.id)
+            console.log("Name:", response.data.name)
+            console.log("Collection:", response.data.collection.name)
+            console.log("Updated At:", response.data.updated_at)
+            console.log("Database ID:", response.data.dataset_query.database)
+        } catch (error) {
+            if (error.response) {
+                console.log("\nError!", error.response.status, error.response.statusText);
+                console.log(error.response.data);
+            } else{
+                console.log(error);
+            }
+            
+        }   
+    }
+})
+
+yargs.command({
     command: 'update-deprecated',
     describe: 'Update question',
     builder: {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+    source:
+        image: mafs/metabase-custom
+        ports:
+            - 3000:3000
+    destination:
+        image: mafs/metabase-custom
+        ports:
+            - 3001:3000

--- a/src/metabase-async-await.js
+++ b/src/metabase-async-await.js
@@ -93,7 +93,7 @@ async function duplicateAcross(questionId, collectionId, questionName, databaseI
 
   const body = {
     visualization_settings,
-    description,
+    description: description ? description : null,
     collection_id: collectionId,
     collection_position,
     result_metadata,

--- a/src/metabase-async-await.js
+++ b/src/metabase-async-await.js
@@ -6,6 +6,12 @@ const baseUrl = process.env.METABASE_BASE_URL
 const username = process.env.METABASE_USERNAME
 const password = process.env.METABASE_PASSWORD
 
+const {
+  DESTINATION_METABASE_BASE_URL,
+  DESTINATION_METABASE_USERNAME,
+  DESTINATION_METABASE_PASSWORD
+} = process.env;
+
 async function update(originQuestionId, destinationQuestionId, destinationDatabaseId) {
   console.log("Authenticating",username);
   const axiosConfig = await auth();
@@ -69,6 +75,66 @@ async function duplicate(questionId, collectionId, questionName, databaseId) {
   return response;
 }
 
+async function duplicateAcross(questionId, collectionId, questionName, databaseId) {
+  console.log("Authenticating",username);
+  const axiosConfigSource = await auth();
+  console.log("Successfully authenticated to source with token", axiosConfigSource.headers);
+
+  console.log("Authenticating",DESTINATION_METABASE_USERNAME);
+  const axiosConfigDestination = await destinationAuth();
+  console.log("Successfully authenticated to destination with token", axiosConfigDestination.headers);
+
+  console.log("From source retrieving question id", questionId);
+  const {visualization_settings, description, enable_embedding, collection_position,
+     result_metadata, dataset_query, display, embedding_params, name:oldName } = await getQuestion(questionId, axiosConfigSource);
+  dataset_query.database = databaseId;
+
+  const name = questionName ? questionName : oldName;
+
+  const body = {
+    visualization_settings,
+    description,
+    collection_id: collectionId,
+    collection_position,
+    result_metadata,
+    dataset_query,
+    name,
+    display,
+    enable_embedding,
+    embedding_params
+  };
+  console.log("\nCreating new question on destination with payload...");
+  console.log(body);
+  const url = DESTINATION_METABASE_BASE_URL + "/card/";
+
+  const response = await axios.post(url, body, axiosConfigDestination);
+  return response;
+}
+
+async function destinationAuth() {
+  try {
+      const authResponse = await axios({
+          method: 'post',
+          url: DESTINATION_METABASE_BASE_URL+ "/session",
+          data: {
+              username: DESTINATION_METABASE_USERNAME,
+              password: DESTINATION_METABASE_PASSWORD
+          }
+      });
+      const token = authResponse.data.id;
+      const axiosConfig = {
+          headers: {
+              "X-Metabase-Session": token
+          }
+      };
+      
+      return axiosConfig;
+  } catch (error) {
+      console.log("error", error.response.status);
+      return
+  }
+}
+
 async function auth() {
   try {
       const authResponse = await axios({
@@ -105,5 +171,5 @@ async function getQuestion(id, axiosConfig) {
 
 
 module.exports = {
-  update, duplicate
+  update, duplicate, duplicateAcross
 }


### PR DESCRIPTION
This is what we're doing to be able to launch 2 instances (source and destination) and run test commands against. Allows for a complete sandbox environment that can later be used to run automated tests.

Instructions to recreate docker images in the README if you'd like to create your own, but they're very basic and contain only one autogenerated dashboard and set of cards. I'm not aware/don't have time to figure out unattended installs of metabase and generate the script to create an image for each version, but that would be a great +1 if someone else knows how to. Then tests could also be added and automated against many versions of metabase.

Closing #11 since this pull makes it redundant.